### PR TITLE
Fix #138

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -57,5 +57,6 @@ Imports:
 LazyData: true
 Suggests: 
     knitr,
-    rmarkdown
+    rmarkdown,
+    data.table
 VignetteBuilder: knitr

--- a/R/airship.R
+++ b/R/airship.R
@@ -124,7 +124,8 @@ airship <- function(
   
   "%>%" <- dplyr::"%>%"
   
-  ind_missing_package <- !dependencies %in% utils::installed.packages()[ ,"Package"]
+  installed_packages_ <- utils::installed.packages()[ ,"Package"]
+  ind_missing_package <- !dependencies %in% installed_packages_
   
   if (any(ind_missing_package)) {
     n_missing_packages <- sum(ind_missing_package)
@@ -160,6 +161,8 @@ airship <- function(
       )
     )
   }
+  
+  dt_pkg_available <- "data.table" %in% installed_packages_
   
   # Global Options ----
   options(shiny.sanitize.errors = FALSE) 
@@ -695,12 +698,13 @@ airship <- function(
         
         dfCandidate <-
           try(
-            utils::read.csv(
+            read_csv_(
               inFile$datapath,
               header = TRUE,
               sep = input$sep,
               skip = input$rowSkip,
-              stringsAsFactors = TRUE
+              stringsAsFactors = TRUE, 
+              use_data_table = dt_pkg_available
             )
           )
         
@@ -719,13 +723,15 @@ airship <- function(
         ) - 1
         
         dfCandidate <-
+          
           try(
-            utils::read.csv(
-              inFile$datapath, 
-              header = TRUE, 
+            read_csv_(
+              inFile$datapath,
+              header = TRUE,
               sep = input$sep,
-              skip = deleterows, 
-              stringsAsFactors = TRUE
+              skip = deleterows,
+              stringsAsFactors = TRUE, 
+              use_data_table = dt_pkg_available
             )
           )
         
@@ -755,6 +761,10 @@ airship <- function(
           dfCandidate[, -which(colnames(dfCandidate) == "X")]
       }
       
+      if ("#X" %in% colnames(dfCandidate)) {
+        dfCandidate <- dfCandidate[, -which(colnames(dfCandidate) == "#X")]
+      }
+      
       # Get rid of empty columns
       dfCandidate <- dfCandidate[,colSums(is.na(dfCandidate)) < nrow(dfCandidate)]
       
@@ -773,7 +783,6 @@ airship <- function(
       
       # Return dfCandidate
       dfCandidate
-      
     })
     
     

--- a/R/fnHelpers.R
+++ b/R/fnHelpers.R
@@ -1,0 +1,33 @@
+# Helper for reading csv files. If data.table=TRUE, data.table::fread is used
+read_csv_ <- function(file, 
+                      header, 
+                      sep, 
+                      skip, 
+                      stringsAsFactors = TRUE, 
+                      use_data_table = FALSE,
+                      ...) {
+  
+  if (use_data_table) {
+    
+    data.table::fread(
+      file = file,
+      header = header,
+      sep = sep,
+      skip = skip,
+      stringsAsFactors = stringsAsFactors,
+      data.table = FALSE, 
+      ...
+    )
+    
+  } else {
+    
+    utils::read.csv(
+      file,
+      header = header, 
+      sep = sep,
+      skip = skip, 
+      stringsAsFactors = stringsAsFactors,
+      ...
+    )  
+  }
+}


### PR DESCRIPTION
This pull request addresses issue #138. 

I made sure that the final column names remain consistent for the example dataset `ExampleDataFACTS.csv`, regardless of whether the data is loaded using `read.csv` or `data.table::fread` (if installed).

There may be a merge conflict related to pull request #137 that closes #136.
