### PR TITLE
Michal majka issue #102

### DIFF
--- a/R/airship.R
+++ b/R/airship.R
@@ -491,6 +491,7 @@ airship <- function(
               
               shiny::column(
                 width = 3,
+                airship:::fnBoxplotOutlierUI("boxplot"),
                 airship:::fnColorUI("boxplot")
               ),
               

--- a/R/fnBoxplot.R
+++ b/R/fnBoxplot.R
@@ -38,6 +38,25 @@ fnBoxplotUI <-
     
   }
 
+fnBoxplotOutlierUI <- 
+  function(
+    cID
+  ) {
+    
+    shiny::tagList(
+      
+      shiny::conditionalPanel(
+        condition = "input.cType == 'Boxplot'",
+        ns = shiny::NS("boxplot"),
+        
+        checkboxInput(NS(cID, "showoutliers"), 
+                      label = "Show outliers?",
+                      value = TRUE)
+      ) 
+      
+    )
+  }
+
 fnBoxplotServer <- 
   function(
     cID,
@@ -66,12 +85,14 @@ fnBoxplotServer <-
           
           lPlot$lggPlot <-
             lPlot$lggPlot +
-            ggplot2::geom_boxplot(alpha = input$dAlpha)
+            ggplot2::geom_boxplot(alpha = input$dAlpha,
+                                  outlier.shape = if (input$showoutliers) NULL else ""
+                                  )
           
           lPlot$lCode$boxplot <- 
             paste0(
-              " + ggplot2::geom_boxplot(alpha = ", 
-              input$dAlpha,
+              " + ggplot2::geom_boxplot(alpha = ", input$dAlpha,
+              ifelse(!input$showoutliers, ", outlier.shape = ''", ""),
               ")"
             )
           
@@ -94,3 +115,5 @@ fnBoxplotServer <-
       }
       
     )}
+
+

--- a/R/fnDynFilterData.R
+++ b/R/fnDynFilterData.R
@@ -78,7 +78,7 @@ fnDynFilterData <-
           shiny::validate(
             shiny::need(
               err_ != "",
-              "If you have recently submitted a new dataset, check if the focus variables are set correctly. If you haven't changed the dataset or have to wait too long, please report a bug in fnDynFilterData."
+              "If you have recently submitted a new dataset, check if the focus variables are set correctly.\nIf you haven't changed the dataset or have to wait too long, please report a bug in fnDynFilterData."
             )
           )
         }


### PR DESCRIPTION
This pull request closes #102. It was tested based on the example dataset "Toy simulation study".

There is now a new widget based on `checkboxInput` with a label `Show outliers?` that allows hiding outliers.
The reproducible code is shown accordingly.

<img width="1436" alt="fixing_issue_102_boxplot_outliers" src="https://github.com/el-meyer/airship/assets/29159112/a19ec0e0-059e-40e2-840e-f7c0bfe041ff">

In addition, an informative error has been split into two lines, such that it doesn't go over the border (on my laptop it was the case) and it is more readable.

<img width="1437" alt="more_transparent_informative_error" src="https://github.com/el-meyer/airship/assets/29159112/7928fbc7-ef41-43b3-8f78-21aaaf339864">
